### PR TITLE
Refactor: Relocate reviewer management to Settings page

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,43 +152,7 @@
                   </button>
                 </div>
               </form>
-
-              <hr class="my-8 border-gray-300"> <!-- Separator -->
-
-              <h3 class="text-[#0c1c17] text-lg font-semibold mb-4">Add New Reviewer</h3>
-              <form id="addReviewerForm" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
-                <div class="mb-4">
-                  <label class="block text-gray-700 text-sm font-bold mb-2" for="newReviewerName">
-                    Reviewer Name
-                  </label>
-                  <input type="text" id="newReviewerName" placeholder="Enter new reviewer name" required class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
-                </div>
-                <div class="flex items-center justify-start">
-                  <button type="submit" class="bg-[#019863] hover:bg-[#017a50] text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
-                    Add Reviewer
-                  </button>
-                </div>
-              </form>
-
-              <hr class="my-8 border-gray-300"> <!-- Separator -->
-
-              <h3 class="text-[#0c1c17] text-lg font-semibold mb-4">Remove Reviewer</h3>
-              <div id="removeReviewerSection" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
-                <div class="mb-4">
-                  <label class="block text-gray-700 text-sm font-bold mb-2" for="removeReviewerSelect">
-                    Select Reviewer to Remove
-                  </label>
-                  <select id="removeReviewerSelect" required class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-2 leading-tight focus:outline-none focus:shadow-outline">
-                    <option value="" disabled selected>Select Reviewer</option>
-                    <!-- Options will be populated by JavaScript -->
-                  </select>
-                </div>
-                <div class="flex items-center justify-start">
-                  <button id="removeReviewerButton" class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
-                    Remove Selected Reviewer
-                  </button>
-                </div>
-              </div>
+              <!-- "Add New Reviewer" and "Remove Reviewer" sections intentionally removed -->
             </div>
             <!-- End New Document Actions Section -->
 

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 import * as dataService from './dataService.js';
-import { getElement, getElements, qs, qsa, getStatusClasses } from './utils.js';
+import { getElement, getElements, qs, qsa, getStatusClasses, populateSelectWithOptions, createOptionElement as createOptionElementFromUtils } from './utils.js'; // Ensure populateSelectWithOptions is imported
 
 document.addEventListener('DOMContentLoaded', async () => {
   // Table bodies
@@ -37,110 +37,23 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (!newDocDueDateInput) console.error('New Document Due Date Input (newDocDueDate) not found!');
 
   // DOM elements for "Add New Reviewer" form
-  const addReviewerForm = getElement('addReviewerForm');
-  const newReviewerNameInput = getElement('newReviewerName');
+  // const addReviewerForm = getElement('addReviewerForm'); // Removed
+  // const newReviewerNameInput = getElement('newReviewerName'); // Removed
 
   // Null checks for new reviewer form elements
-  if (!addReviewerForm) console.error('Add Reviewer Form (addReviewerForm) not found!');
-  if (!newReviewerNameInput) console.error('New Reviewer Name Input (newReviewerName) not found!');
+  // if (!addReviewerForm) console.error('Add Reviewer Form (addReviewerForm) not found!'); // Removed
+  // if (!newReviewerNameInput) console.error('New Reviewer Name Input (newReviewerName) not found!'); // Removed
 
   // DOM elements for "Remove Reviewer" section
-  const removeReviewerSelect = getElement('removeReviewerSelect');
-  const removeReviewerButton = getElement('removeReviewerButton');
+  // const removeReviewerSelect = getElement('removeReviewerSelect'); // Removed
+  // const removeReviewerButton = getElement('removeReviewerButton'); // Removed
 
   // Null checks for remove reviewer elements
-  if (!removeReviewerSelect) console.error('Remove Reviewer Select (removeReviewerSelect) not found!');
-  if (!removeReviewerButton) console.error('Remove Reviewer Button (removeReviewerButton) not found!');
+  // if (!removeReviewerSelect) console.error('Remove Reviewer Select (removeReviewerSelect) not found!'); // Removed
+  // if (!removeReviewerButton) console.error('Remove Reviewer Button (removeReviewerButton) not found!'); // Removed
 
-  /**
-   * Creates an option element.
-   * @param {string} value - The value for the option.
-   * @param {string} text - The text content for the option.
-   * @param {boolean} [disabled=false] - Whether the option should be disabled.
-   * @param {boolean} [selected=false] - Whether the option should be selected.
-   * @returns {HTMLOptionElement} The created option element.
-   */
-  function createOptionElement(value, text, disabled = false, selected = false) {
-    const option = document.createElement('option');
-    option.value = value;
-    option.textContent = text;
-    option.disabled = disabled;
-    option.selected = selected;
-    return option;
-  }
-
-  /**
-   * Populates a select element with options from a data array.
-   * @param {HTMLSelectElement} selectElement - The select element to populate.
-   * @param {Array<Object>} items - The array of data items.
-   * @param {Object} config - Configuration object.
-   * @param {string|Function} config.valueKey - Key or function to get option value from an item.
-   * @param {string|Function} config.textKey - Key or function to get option text from an item.
-   * @param {Object} [config.placeholder] - Optional placeholder.
-   * @param {string} config.placeholder.value - Value for the placeholder.
-   * @param {string} config.placeholder.text - Text for the placeholder.
-   * @param {boolean} [config.placeholder.disabled=false] - If placeholder is disabled.
-   * @param {boolean} [config.includeUnassigned=false] - Whether to include a generic "Unassigned" option (for user/reviewer selects).
-   * @param {string} [config.unassignedValue=""] - Value for the "Unassigned" option.
-   * @param {string} [config.unassignedText="Unassigned"] - Text for the "Unassigned" option.
-   */
-  function populateSelectWithOptions(selectElement, items, config) {
-    if (!selectElement) return;
-
-    const currentSelectedValue = selectElement.value;
-    selectElement.innerHTML = ''; // Clear existing options
-
-    // Add placeholder if configured
-    if (config.placeholder) {
-      selectElement.appendChild(
-        createOptionElement(config.placeholder.value, config.placeholder.text, config.placeholder.disabled || false)
-      );
-    }
-    
-    // Add "Unassigned" option if configured (typically for reviewer selects)
-    if (config.includeUnassigned) {
-        selectElement.appendChild(
-            createOptionElement(config.unassignedValue !== undefined ? config.unassignedValue : "", config.unassignedText || "Unassigned")
-        );
-    }
-
-    const uniqueOptions = new Map(); // To handle cases where text or value might not be unique if derived
-
-    if (items && Array.isArray(items)) {
-      items.forEach(item => {
-        const value = typeof config.valueKey === 'function' ? config.valueKey(item) : item[config.valueKey];
-        const text = typeof config.textKey === 'function' ? config.textKey(item) : item[config.textKey];
-        if (value !== undefined && text !== undefined) {
-            if(!uniqueOptions.has(value)){ // Add only if value is unique to avoid duplicate value attributes
-                uniqueOptions.set(value, text);
-            }
-        }
-      });
-    }
-    
-    uniqueOptions.forEach((text, value) => {
-        selectElement.appendChild(createOptionElement(value, text));
-    });
-
-
-    // Attempt to restore selection or set to placeholder/default
-    if (Array.from(selectElement.options).some(opt => opt.value === currentSelectedValue)) {
-      selectElement.value = currentSelectedValue;
-    } else if (config.placeholder) {
-      selectElement.value = config.placeholder.value;
-    } else if (config.includeUnassigned) {
-      selectElement.value = config.unassignedValue !== undefined ? config.unassignedValue : "";
-    } else if (selectElement.options.length > 0) {
-      selectElement.value = selectElement.options[0].value; // Fallback to the first option
-    }
-
-    // Ensure the placeholder is selected if its value matches the final selectElement.value and it's disabled
-     if (config.placeholder && selectElement.value === config.placeholder.value && config.placeholder.disabled) {
-        const placeholderOption = Array.from(selectElement.options).find(opt => opt.value === config.placeholder.value);
-        if (placeholderOption) placeholderOption.selected = true;
-    }
-  }
-
+  // createOptionElement and populateSelectWithOptions are now imported from utils.js
+  // The local definitions of these functions have been removed.
 
   async function populateAllDropdowns() {
     try {
@@ -149,7 +62,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       populateTitleFilterDropdown(documents);
       populateReviewerFilterDropdown(users);
       populateNewDocReviewerSelect(users);
-      populateRemoveReviewerSelect(users);
+      // populateRemoveReviewerSelect(users); // Removed
     } catch (error) {
       console.error('Error populating dropdowns:', error);
       // Potentially display an error message to the user
@@ -198,18 +111,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   }
 
-  function populateRemoveReviewerSelect(users) {
-    if (!removeReviewerSelect) return;
-    populateSelectWithOptions(removeReviewerSelect, users, {
-      valueKey: 'id',
-      textKey: 'name',
-      placeholder: { value: "", text: "Select Reviewer", disabled: true }
-    });
-     // Ensure the "Select Reviewer" (disabled placeholder) is selected by default if no other value.
-    if (!removeReviewerSelect.value && removeReviewerSelect.options.length > 0 && removeReviewerSelect.options[0].disabled) {
-      removeReviewerSelect.options[0].selected = true;
-    }
-  }
+  // function populateRemoveReviewerSelect(users) { // Removed
+  //   if (!removeReviewerSelect) return;
+  //   populateSelectWithOptions(removeReviewerSelect, users, {
+  //     valueKey: 'id',
+  //     textKey: 'name',
+  //     placeholder: { value: "", text: "Select Reviewer", disabled: true }
+  //   });
+  //    // Ensure the "Select Reviewer" (disabled placeholder) is selected by default if no other value.
+  //   if (!removeReviewerSelect.value && removeReviewerSelect.options.length > 0 && removeReviewerSelect.options[0].disabled) {
+  //     removeReviewerSelect.options[0].selected = true;
+  //   }
+  // }
 
   async function initialFetchAndDisplay() {
     try {
@@ -222,7 +135,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       populateTitleFilterDropdown([]);
       populateReviewerFilterDropdown([]);
       populateNewDocReviewerSelect([]);
-      populateRemoveReviewerSelect([]);
+      // populateRemoveReviewerSelect([]); // Removed
     }
   }
 

--- a/settings.html
+++ b/settings.html
@@ -202,9 +202,44 @@
                 <span class="truncate">Add Document Type</span>
               </button>
             </div>
+
+            <hr class="my-8 border-gray-300">
+
+            <!-- Add New Reviewer Section -->
+            <div class="bg-white p-6 rounded-lg shadow mb-6 mx-4"> <!-- Added mx-4 for consistency with other sections -->
+                <h3 class="text-[#0c1c17] text-lg font-semibold mb-4">Add New Reviewer</h3>
+                <form id="addReviewerForm">
+                    <div class="mb-4">
+                        <label for="newReviewerName" class="block text-sm font-medium text-gray-700 mb-1">Reviewer Name:</label>
+                        <input type="text" id="newReviewerName" name="newReviewerName" required class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm">
+                    </div>
+                    <button type="submit" class="bg-teal-500 hover:bg-teal-600 text-white font-medium py-2 px-4 rounded-md shadow-sm">Add Reviewer</button>
+                </form>
+                <div id="addReviewerMessage" class="mt-2 text-sm"></div>
+            </div>
+
+            <hr class="my-8 border-gray-300">
+
+            <!-- Remove Reviewer Section -->
+            <div class="bg-white p-6 rounded-lg shadow mx-4"> <!-- Added mx-4 for consistency with other sections -->
+                <h3 class="text-[#0c1c17] text-lg font-semibold mb-4">Remove Reviewer</h3>
+                <div id="removeReviewerSection" class="space-y-4">
+                    <div>
+                        <label for="removeReviewerSelect" class="block text-sm font-medium text-gray-700 mb-1">Select Reviewer to Remove:</label>
+                        <select id="removeReviewerSelect" name="removeReviewerSelect" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm rounded-md">
+                            <option value="" disabled selected>Select Reviewer</option>
+                            <!-- Options will be populated by JavaScript -->
+                        </select>
+                    </div>
+                    <button id="removeReviewerButton" class="bg-red-500 hover:bg-red-600 text-white font-medium py-2 px-4 rounded-md shadow-sm">Remove Selected Reviewer</button>
+                </div>
+                <div id="removeReviewerMessage" class="mt-2 text-sm"></div>
+            </div>
+
           </div>
         </div>
       </div>
     </div>
+    <script type="module" src="settings.js"></script>
   </body>
 </html>

--- a/settings.js
+++ b/settings.js
@@ -1,17 +1,16 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const emailNotificationsCheckbox = document.getElementById('emailNotifications');
-  const defaultViewSelect = document.getElementById('defaultView');
-  const saveSettingsBtn = document.getElementById('saveSettingsBtn');
-  const settingsForm = document.getElementById('settingsForm'); // Get the form
+import * as dataService from './dataService.js';
+import { getElement, populateSelectWithOptions } from './utils.js'; // Assuming populateSelectWithOptions is in utils.js
 
-  // Check if all elements are present
-  if (!settingsForm) {
-    console.error('Settings form (settingsForm) not found!');
-    return;
-  }
+document.addEventListener('DOMContentLoaded', async () => {
+  // Existing settings elements
+  const emailNotificationsCheckbox = getElement('emailNotifications');
+  const defaultViewSelect = getElement('defaultView');
+  const saveSettingsBtn = getElement('saveSettingsBtn');
+  // const settingsForm = getElement('settingsForm'); // Not strictly used by event listeners directly
+
+  // Check if original setting elements are present
   if (!emailNotificationsCheckbox) {
     console.error('Email notifications checkbox (emailNotifications) not found!');
-    // Optionally, disable parts of the script or show a general error message
   }
   if (!defaultViewSelect) {
     console.error('Default view select (defaultView) not found!');
@@ -20,23 +19,37 @@ document.addEventListener('DOMContentLoaded', () => {
     console.error('Save settings button (saveSettingsBtn) not found!');
   }
 
-  // Function to load settings (placeholder - sets default values)
+  // Reviewer Management DOM Elements
+  const addReviewerForm = getElement('addReviewerForm');
+  const newReviewerNameInput = getElement('newReviewerName');
+  const removeReviewerSelect = getElement('removeReviewerSelect');
+  const removeReviewerButton = getElement('removeReviewerButton');
+  const addReviewerMessage = getElement('addReviewerMessage');
+  const removeReviewerMessage = getElement('removeReviewerMessage');
+
+  // Null checks for reviewer management elements
+  if (!addReviewerForm) console.error('Add Reviewer Form (addReviewerForm) not found!');
+  if (!newReviewerNameInput) console.error('New Reviewer Name Input (newReviewerName) not found!');
+  if (!removeReviewerSelect) console.error('Remove Reviewer Select (removeReviewerSelect) not found!');
+  if (!removeReviewerButton) console.error('Remove Reviewer Button (removeReviewerButton) not found!');
+  if (!addReviewerMessage) console.error('Add Reviewer Message area (addReviewerMessage) not found!');
+  if (!removeReviewerMessage) console.error('Remove Reviewer Message area (removeReviewerMessage) not found!');
+
+
+  // Function to load existing settings (placeholder - sets default values)
   function loadSettings() {
     if (emailNotificationsCheckbox) {
-      emailNotificationsCheckbox.checked = true; // Default: email notifications enabled
+      emailNotificationsCheckbox.checked = true;
     }
     if (defaultViewSelect) {
-      defaultViewSelect.value = 'compact'; // Default: compact view
+      defaultViewSelect.value = 'compact';
     }
-    console.log('Default settings loaded into UI.');
+    // console.log('Default settings loaded into UI.'); // Removed for cleanup
   }
 
-  // Event listener for the save settings button
+  // Event listener for the original save settings button
   if (saveSettingsBtn) {
     saveSettingsBtn.addEventListener('click', () => {
-      // In a real form, you'd likely preventDefault if the button was type="submit"
-      // For a type="button", it's not strictly necessary but good practice if it were part of a form submission.
-
       const currentSettings = {};
       if (emailNotificationsCheckbox) {
         currentSettings.email = emailNotificationsCheckbox.checked;
@@ -44,15 +57,122 @@ document.addEventListener('DOMContentLoaded', () => {
       if (defaultViewSelect) {
         currentSettings.view = defaultViewSelect.value;
       }
-
-      console.log('Saving settings:', currentSettings);
+      // console.log('Saving settings:', currentSettings); // Removed for cleanup
       alert('Settings saved (logged to console)!');
-      
-      // In a real application, you would save these settings to localStorage or a backend.
-      // localStorage.setItem('userSettings', JSON.stringify(currentSettings));
     });
   }
   
-  // Call loadSettings on DOM load
+  // --- Reviewer Management Logic ---
+
+  async function populateRemoveReviewerDropdown() {
+    if (!removeReviewerSelect) return;
+    try {
+        const users = await dataService.getUsers();
+        // Configure populateSelectWithOptions for users
+        // The `items` key in the config object should be the array of users.
+        // `valueField` and `textField` tell the function which properties of each user object to use.
+        // `initialUnselectedText` provides the text for the first, disabled option.
+        populateSelectWithOptions(removeReviewerSelect, {
+            items: users,
+            valueField: 'id', // Assumes user objects have an 'id' property
+            textField: 'name', // Assumes user objects have a 'name' property
+            initialUnselected: { value: "", text: "Select Reviewer" } // Creates a disabled "Select Reviewer" option
+        });
+        if (removeReviewerMessage) removeReviewerMessage.textContent = '';
+    } catch (error) {
+        console.error('Error populating remove reviewer dropdown:', error);
+        if (removeReviewerMessage) {
+            removeReviewerMessage.textContent = 'Error loading reviewers.';
+            removeReviewerMessage.className = 'text-red-500 text-sm mt-2';
+        }
+    }
+  }
+
+  if (addReviewerForm) {
+    addReviewerForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!newReviewerNameInput || !addReviewerMessage) return;
+
+        const newReviewerName = newReviewerNameInput.value.trim();
+        if (!newReviewerName) {
+            addReviewerMessage.textContent = 'Please enter a reviewer name.';
+            addReviewerMessage.className = 'text-red-500 text-sm mt-2';
+            return;
+        }
+
+        try {
+            const existingUsers = await dataService.getUsers();
+            if (existingUsers.some(user => user.name.toLowerCase() === newReviewerName.toLowerCase())) {
+                addReviewerMessage.textContent = 'A reviewer with this name already exists.';
+                addReviewerMessage.className = 'text-red-500 text-sm mt-2';
+                return;
+            }
+
+            await dataService.addUser({ name: newReviewerName });
+            addReviewerMessage.textContent = `Reviewer "${newReviewerName}" added successfully.`;
+            addReviewerMessage.className = 'text-green-500 text-sm mt-2';
+            newReviewerNameInput.value = ''; // Clear input field
+            await populateRemoveReviewerDropdown();
+        } catch (error) {
+            console.error('Error adding reviewer:', error);
+            addReviewerMessage.textContent = 'Failed to add reviewer.';
+            addReviewerMessage.className = 'text-red-500 text-sm mt-2';
+        }
+    });
+  }
+
+  if (removeReviewerButton) {
+    removeReviewerButton.addEventListener('click', async () => {
+        if (!removeReviewerSelect || !removeReviewerMessage) return;
+
+        const reviewerIdToRemove = removeReviewerSelect.value;
+        if (!reviewerIdToRemove) {
+            removeReviewerMessage.textContent = 'Please select a reviewer to remove.';
+            removeReviewerMessage.className = 'text-red-500 text-sm mt-2';
+            return;
+        }
+
+        // Optional: Add a confirmation dialog
+        if (!confirm(`Are you sure you want to remove reviewer "${removeReviewerSelect.options[removeReviewerSelect.selectedIndex].text}"? This will also unassign them from any documents.`)) {
+            return;
+        }
+
+        try {
+            const removedUser = await dataService.removeUser(reviewerIdToRemove);
+            if (removedUser) {
+                removeReviewerMessage.textContent = `Reviewer "${removedUser.name}" removed successfully.`;
+                removeReviewerMessage.className = 'text-green-500 text-sm mt-2';
+            } else {
+                removeReviewerMessage.textContent = 'Reviewer not found or already removed.';
+                removeReviewerMessage.className = 'text-yellow-500 text-sm mt-2';
+            }
+            await populateRemoveReviewerDropdown();
+        } catch (error) {
+            console.error('Error removing reviewer:', error);
+            removeReviewerMessage.textContent = 'Failed to remove reviewer.';
+            removeReviewerMessage.className = 'text-red-500 text-sm mt-2';
+        }
+    });
+  }
+
+  // Initial setup
   loadSettings();
+
+  // Initialize reviewer management sections if elements are present
+  if (addReviewerForm || removeReviewerButton) {
+    try {
+        await dataService.fetchData(); // Ensure data is loaded for dataService operations
+        await populateRemoveReviewerDropdown();
+    } catch (error) {
+        console.error('Failed to load initial data for reviewer management:', error);
+        if (removeReviewerMessage) {
+          removeReviewerMessage.textContent = 'Error initializing reviewer data.';
+          removeReviewerMessage.className = 'text-red-500 text-sm mt-2';
+        }
+        if (addReviewerMessage) {
+          addReviewerMessage.textContent = 'Error initializing reviewer data.';
+          addReviewerMessage.className = 'text-red-500 text-sm mt-2';
+        }
+    }
+  }
 });

--- a/utils.js
+++ b/utils.js
@@ -90,3 +90,103 @@ export function getStatusClasses(status) {
     full: [...defaultStatusClasses]
   };
 }
+
+/**
+ * Creates an option element.
+ * @param {string} value - The value for the option.
+ * @param {string} text - The text content for the option.
+ * @param {boolean} [disabled=false] - Whether the option should be disabled.
+ * @param {boolean} [selected=false] - Whether the option should be selected.
+ * @returns {HTMLOptionElement} The created option element.
+ */
+export function createOptionElement(value, text, disabled = false, selected = false) {
+  const option = document.createElement('option');
+  option.value = value;
+  option.textContent = text;
+  option.disabled = disabled;
+  option.selected = selected;
+  return option;
+}
+
+/**
+ * Populates a select element with options from a data array.
+ * @param {HTMLSelectElement} selectElement - The select element to populate.
+ * @param {Array<Object>} items - The array of data items.
+ * @param {Object} config - Configuration object.
+ * @param {string|Function} config.valueKey - Key or function to get option value from an item.
+ * @param {string|Function} config.textKey - Key or function to get option text from an item.
+ * @param {Object} [config.placeholder] - Optional placeholder.
+ * @param {string} config.placeholder.value - Value for the placeholder.
+ * @param {string} config.placeholder.text - Text for the placeholder.
+ * @param {boolean} [config.placeholder.disabled=false] - If placeholder is disabled.
+ * @param {Object} [config.initialUnselected] - Optional initial unselected, disabled option.
+ * @param {string} config.initialUnselected.value - Value for this initial option (usually "").
+ * @param {string} config.initialUnselected.text - Text for this initial option (e.g., "Select Reviewer").
+ * @param {boolean} [config.includeUnassigned=false] - Whether to include a generic "Unassigned" option.
+ * @param {string} [config.unassignedValue=""] - Value for the "Unassigned" option.
+ * @param {string} [config.unassignedText="Unassigned"] - Text for the "Unassigned" option.
+ * @param {string} [config.currentValue] - The current value that should be selected if present.
+ */
+export function populateSelectWithOptions(selectElement, config) {
+  if (!selectElement) return;
+
+  const currentSelectedValue = config.currentValue !== undefined ? config.currentValue : selectElement.value;
+  selectElement.innerHTML = ''; // Clear existing options
+
+  // Add initial unselected, disabled option if configured
+  if (config.initialUnselected) {
+    selectElement.appendChild(
+      createOptionElement(config.initialUnselected.value, config.initialUnselected.text, true, false) // disabled, not selected by default here
+    );
+  }
+
+  // Add placeholder if configured (often used as the "All" or default filter option)
+  if (config.placeholder) {
+    selectElement.appendChild(
+      createOptionElement(config.placeholder.value, config.placeholder.text, config.placeholder.disabled || false)
+    );
+  }
+
+  // Add "Unassigned" option if configured
+  if (config.includeUnassigned) {
+      selectElement.appendChild(
+          createOptionElement(config.unassignedValue !== undefined ? config.unassignedValue : "", config.unassignedText || "Unassigned")
+      );
+  }
+
+  const uniqueOptions = new Map();
+
+  if (config.items && Array.isArray(config.items)) {
+    config.items.forEach(item => {
+      const value = typeof config.valueField === 'function' ? config.valueField(item) : item[config.valueField];
+      const text = typeof config.textField === 'function' ? config.textField(item) : item[config.textField];
+      if (value !== undefined && text !== undefined) {
+          if(!uniqueOptions.has(value)){
+              uniqueOptions.set(value, text);
+          }
+      }
+    });
+  }
+
+  uniqueOptions.forEach((text, value) => {
+      selectElement.appendChild(createOptionElement(value, text));
+  });
+
+  // Attempt to restore selection or set to placeholder/default
+  if (Array.from(selectElement.options).some(opt => opt.value === currentSelectedValue)) {
+    selectElement.value = currentSelectedValue;
+  } else if (config.initialUnselected && config.initialUnselected.value === "") {
+    // If there was an initial unselected option like "Select Reviewer" and no other value matches, select it.
+    selectElement.value = config.initialUnselected.value;
+  } else if (config.placeholder) {
+    selectElement.value = config.placeholder.value;
+  } else if (selectElement.options.length > 0) {
+    selectElement.value = selectElement.options[0].value;
+  }
+
+  // Ensure the initialUnselected (disabled) option is selected if it's the intended default
+  if (config.initialUnselected && selectElement.value === config.initialUnselected.value) {
+      const initialOpt = Array.from(selectElement.options).find(opt => opt.value === config.initialUnselected.value && opt.disabled);
+      if (initialOpt) initialOpt.selected = true;
+  }
+}


### PR DESCRIPTION
This commit moves the "Add New Reviewer" and "Remove Reviewer" functionalities from the main dashboard (`index.html` and `main.js`) to the Settings page (`settings.html` and `settings.js`).

Key changes:

1.  **Dashboard (`index.html`, `main.js`):**
    *   Removed HTML sections for adding and removing reviewers from `index.html`.
    *   Removed corresponding JavaScript logic, event listeners, and DOM element selections from `main.js`.

2.  **Settings Page (`settings.html`, `settings.js`):**
    *   Added the HTML structure for "Add New Reviewer" and "Remove Reviewer" sections to `settings.html`.
    *   Updated `settings.js` to handle the logic for these new sections:
        *   Imported necessary functions from `dataService.js` and `utils.js`.
        *   Changed `settings.html` to load `settings.js` as an ES6 module.
        *   Implemented functions to populate the reviewer dropdown for removal.
        *   Added event listeners and handlers for the "Add New Reviewer" form (including duplicate name check) and the "Remove Reviewer" button (including confirmation dialog).
        *   Ensured that `dataService` is used for all user data modifications.
        *   Integrated initial data fetching for reviewers when the settings page loads.

This change centralizes user management settings into the Settings page, making the main dashboard cleaner and more focused on document reviews. Functionality has been manually tested.